### PR TITLE
Fixed 'require is not defined'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export default function (options = {}) {
       //console.dir(templateFunction.toString());
       let compiled = '';
       //see https://github.com/epeli/node-hbsfy/blob/master/runtime.js for inspiration
-      compiled += "const HandlebarsCompiler = require('handlebars/runtime')['default'];\n";
+      compiled += "import HandlebarsCompiler from 'handlebars/runtime';\n";
       compiled += "export default HandlebarsCompiler.template(" + templateFunction.toString() + ");\n";
       //console.log(compiled);
       return {


### PR DESCRIPTION
The plugin inserts the code `var HandlebarsCompiler = require('handlebars/runtime')['default'];`, which cannot be transformed by the CommonJS plugin. This patch makes the plugin use both ES6 imports and exports for template code (it was already using ES6 exports).